### PR TITLE
SteamOS Update Resilience

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -57,21 +57,6 @@ $ steamos-readonly enable
 $ systemd-sysext merge
 ```
 
-## On system update
-
-Unfortunately, because SteamOS doesn't include a `SYSEXT_LEVEL`, this
-installation method breaks when the system version changes. Repair is simple:
-Re-run the second step of the installation, and everything should come back up
-as you had it.
-
-### Why this happens
-
-Extension images have to declare their compatibility using the OS ID and either
-the SYSEXT_LEVEL or VERSION_ID, which have to match what the system declares.
-
-SteamOS doesn't declare a SYSEXT_LEVEL, and the VERSION_ID increments with every
-system update, so there's no stable values to declare compatibility against.
-
 ## Common issues
 
 ### Broken config file

--- a/tailscale.sh
+++ b/tailscale.sh
@@ -46,7 +46,7 @@ cp -rf $tar_dir/tailscale tailscale/usr/bin/tailscale
 cp -rf $tar_dir/tailscaled tailscale/usr/sbin/tailscaled
 
 # write a systemd extension-release file
-echo -e "ID=steamos\nVERSION_ID=${VERSION_ID}" >> tailscale/usr/lib/extension-release.d/extension-release.tailscale
+echo -e "ID=_any" >> tailscale/usr/lib/extension-release.d/extension-release.tailscale
 
 # create the system extension folder if it doesn't already exist, remove the old version of our tailscale extension, and install our new one
 mkdir -p /var/lib/extensions


### PR DESCRIPTION
I would love to see these changes persist through a SteamOS update. Here are some changes I think will work, but have not been thoroughly tested yet through an actual update. 

From my understanding the only reason this solution breaks on an os update is `systemd-sysext` is comparing `extension-release.tailscaled` against `/etc/os-release` and the versions are not matching.

The idea here is that we stop checking against our system version when mounting the system extension. From [the docs](https://www.freedesktop.org/software/systemd/man/latest/systemd-sysext.html):

> A simple mechanism for version compatibility is enforced: a system extension image must carry a /usr/lib/extension-release.d/extension-release.NAME file, which must match its image name, that is compared with the host os-release file: the contained ID= fields have to match unless "_any" is set for the extension. If the extension ID= is not "_any", the SYSEXT_LEVEL= field (if defined) has to match. If the latter is not defined, the VERSION_ID= field has to match instead.

So I believe if we set `ID` to `_any` it will not continue comparing against `/etc/os-release`. I'm not sure where the `SYSEXT_LEVEL` value is coming from though...

I think we should wait until someone can really test this though.