### PR TITLE
Install without using systemd-sysext

### DIFF
--- a/override.conf
+++ b/override.conf
@@ -1,2 +1,7 @@
 [Service]
-ExtensionDirectories=/var/lib/extensions/tailscale
+ExecStartPre=
+ExecStartPre=/opt/tailscale/tailscaled --cleanup
+ExecStart=
+ExecStart=/opt/tailscale/tailscaled --state=/var/lib/tailscale/tailscaled.state --socket=/run/tailscale/tailscaled.sock --port=${PORT} $FLAGS
+ExecStopPost=
+ExecStopPost=/opt/tailscale/tailscaled --cleanup

--- a/readme.md
+++ b/readme.md
@@ -57,6 +57,21 @@ $ steamos-readonly enable
 $ systemd-sysext merge
 ```
 
+## On system update
+
+Unfortunately, because SteamOS doesn't include a `SYSEXT_LEVEL`, this
+installation method breaks when the system version changes. Repair is simple:
+Re-run the second step of the installation, and everything should come back up
+as you had it.
+
+### Why this happens
+
+Extension images have to declare their compatibility using the OS ID and either
+the SYSEXT_LEVEL or VERSION_ID, which have to match what the system declares.
+
+SteamOS doesn't declare a SYSEXT_LEVEL, and the VERSION_ID increments with every
+system update, so there's no stable values to declare compatibility against.
+
 ## Common issues
 
 ### Broken config file

--- a/readme.md
+++ b/readme.md
@@ -57,21 +57,6 @@ $ steamos-readonly enable
 $ systemd-sysext merge
 ```
 
-## On system update
-
-Unfortunately, because SteamOS doesn't include a `SYSEXT_LEVEL`, this
-installation method breaks when the system version changes. Repair is simple:
-Re-run the second step of the installation, and everything should come back up
-as you had it.
-
-### Why this happens
-
-Extension images have to declare their compatibility using the OS ID and either
-the SYSEXT_LEVEL or VERSION_ID, which have to match what the system declares.
-
-SteamOS doesn't declare a SYSEXT_LEVEL, and the VERSION_ID increments with every
-system update, so there's no stable values to declare compatibility against.
-
 ## Common issues
 
 ### Broken config file

--- a/tailscale.sh
+++ b/tailscale.sh
@@ -72,6 +72,7 @@ cp -rf $tar_dir/tailscaled /opt/tailscale/tailscaled
 # add binaries to path via profile.d
 if ! test -f /etc/profile.d/tailscale.sh; then
   echo 'PATH="$PATH:/opt/tailscale"' >> /etc/profile.d/tailscale.sh
+  source /etc/profile.d/tailscale.sh
 fi
 
 # copy the systemd file into place
@@ -109,3 +110,11 @@ fi
 systemctl restart tailscaled &>/dev/null || echo "ERROR: Could not start tailscaled service" 
 
 echo "done."
+
+if ! command -v tailscale &> /dev/null; then
+  echo "Tailscale is installed and running but the binaries are not in your path yet."
+  echo "Restart your session or run the following command to add them:"
+  echo "" && echo "source /etc/tailscale" && echo ""
+fi
+
+echo "Installation Complete."

--- a/tailscale.sh
+++ b/tailscale.sh
@@ -89,13 +89,13 @@ if test -f /etc/systemd/system/tailscaled.service.d/override.conf; then
   echo "Warning: An existing Tailscaled systemd override file was detected. It must be replaced."
   echo "A backup of the existing file is being placed at /etc/systemd/system/tailscaled.service.d/override.conf.bak"
   echo
-  cp -rf /etc/systemd/system/tailscaled.service.d/override.conf /etc/systemd/system/tailscaled.service.d/override.conf.bak
+  cp -f /etc/systemd/system/tailscaled.service.d/override.conf /etc/systemd/system/tailscaled.service.d/override.conf.bak
   rm /etc/systemd/system/tailscaled.service.d/override.conf
 fi
 
 # copy our override file in
 mkdir -p /etc/systemd/system/tailscaled.service.d
-cp -rf override.conf /etc/systemd/system/tailscaled.service.d/override.conf
+cp -f override.conf /etc/systemd/system/tailscaled.service.d/override.conf
 
 echo "done."
 

--- a/tailscale.sh
+++ b/tailscale.sh
@@ -58,6 +58,7 @@ fi
 # copy the systemd file into place
 cp -rf $tar_dir/systemd/tailscaled.service /etc/systemd/system
 
+# update paths in the unit file
 sed -i 's@/etc/default/tailscaled@/home/deck/.config/tailscaled.defaults@g' /etc/systemd/system/tailscaled.service
 sed -i 's@/usr/sbin/tailscaled@/home/deck/.bin/tailscaled@g' /etc/systemd/system/tailscaled.service
 

--- a/tailscale.sh
+++ b/tailscale.sh
@@ -1,8 +1,5 @@
 #!/usr/bin/env bash
 
-# make system configuration vars available
-source /etc/os-release
-
 # set invocation settings for this script:
 # -e: Exit immediately if a command exits with a non-zero status.
 # -u: Treat unset variables as an error when substituting.

--- a/tailscale.sh
+++ b/tailscale.sh
@@ -46,7 +46,7 @@ cp -rf $tar_dir/tailscale tailscale/usr/bin/tailscale
 cp -rf $tar_dir/tailscaled tailscale/usr/sbin/tailscaled
 
 # write a systemd extension-release file
-echo -e "ID=steamos\nVERSION_ID=${VERSION_ID}" >> tailscale/usr/lib/extension-release.d/extension-release.tailscale
+echo -e "ID=_any" >> tailscale/usr/lib/extension-release.d/extension-release.tailscale
 
 # create the system extension folder if it doesn't already exist, remove the old version of our tailscale extension, and install our new one
 mkdir -p /var/lib/extensions

--- a/tailscale.sh
+++ b/tailscale.sh
@@ -86,6 +86,7 @@ rm -rf "${dir}"
 if ! test -f /etc/systemd/system/tailscaled.service.d/override.conf; then
   mkdir -p /etc/systemd/system/tailscaled.service.d
   cp -rf override.conf /etc/systemd/system/tailscaled.service.d/override.conf
+fi
 
 echo "done."
 

--- a/tailscale.sh
+++ b/tailscale.sh
@@ -45,6 +45,11 @@ mkdir -p /home/deck/.bin
 cp -rf $tar_dir/tailscale /home/deck/.bin/tailscale
 cp -rf $tar_dir/tailscaled /home/deck/.bin/tailscaled
 
+# add binaries to path via bashrc if not already there
+if [ $(cat /home/deck/.bashrc | grep -c "/home/deck/.bin") -eq 0 ]; then
+  echo "/home/deck/.bin" >> /home/deck/.bashrc
+fi
+
 # copy in the defaults file if it doesn't already exist
 if ! test -f /home/deck/.config/tailscaled.defaults; then
   cp -rf $tar_dir/systemd/tailscaled.defaults /home/deck/.config/tailscaled.defaults

--- a/tailscale.sh
+++ b/tailscale.sh
@@ -35,17 +35,17 @@ echo -n "Removing Legacy Installations..."
 
 # Stop and disable the systemd service
 if systemctl is-active --quiet tailscaled; then
-  systemctl stop tailscaled
+  systemctl stop tailscaled &>/dev/null || echo "ERROR: could not stop tailscaled"
 fi
 if systemctl is-enabled --quiet tailscaled; then
-  systemctl disable tailscaled
+  systemctl disable tailscaled &>/dev/null || echo "ERROR: could not disable tailscaled"
 fi
 
 # Remove the systemd system extension
 if [ $(systemd-sysext list | grep -c "/var/lib/extensions/tailscale") -ne 0 ]; then
-  systemd-sysext unmerge > /dev/null
+  systemd-sysext unmerge &>/dev/null || echo "ERROR: could not unmerge system extensions"
   rm -rf /var/lib/extensions/tailscale
-  systemd-sysext merge > /dev/null
+  systemd-sysext merge &>/dev/null || echo "ERROR: could not merge system extensions"
 fi
 
 # Remove the overrides conf
@@ -69,7 +69,6 @@ cp -rf $tar_dir/tailscaled /opt/tailscale/tailscaled
 
 # add binaries to path via profile.d
 if ! test -f /etc/profile.d/tailscale.sh; then
-  mkdir -p /etc/profile.d/tailscale.sh
   echo 'PATH="$PATH:/home/deck/.bin"' >> /etc/profile.d/tailscale.sh
 fi
 

--- a/tailscale.sh
+++ b/tailscale.sh
@@ -85,6 +85,7 @@ rm -rf "${dir}"
 # if an override file already exists, back up and remove
 if test -f /etc/systemd/system/tailscaled.service.d/override.conf; then
   echo
+  echo
   echo "Warning: An existing Tailscaled systemd override file was detected. It must be replaced."
   echo "A backup of the existing file is being placed at /etc/systemd/system/tailscaled.service.d/override.conf.bak"
   echo

--- a/tailscale.sh
+++ b/tailscale.sh
@@ -71,7 +71,7 @@ cp -rf $tar_dir/tailscaled /opt/tailscale/tailscaled
 
 # add binaries to path via profile.d
 if ! test -f /etc/profile.d/tailscale.sh; then
-  echo 'PATH="$PATH:/home/deck/.bin"' >> /etc/profile.d/tailscale.sh
+  echo 'PATH="$PATH:/opt/tailscale"' >> /etc/profile.d/tailscale.sh
 fi
 
 # copy the systemd file into place

--- a/tailscale.sh
+++ b/tailscale.sh
@@ -42,7 +42,7 @@ if systemctl is-enabled --quiet tailscaled; then
 fi
 
 # Remove the systemd system extension
-if [ $(systemd-sysext list | grep -c "/var/lib/extensions/tailscale") -ne 0 ]; then
+if [ $(systemd-sysext list 2>/dev/null | grep -c "/var/lib/extensions/tailscale") -ne 0 ]; then
   systemd-sysext unmerge &>/dev/null || echo "ERROR: could not unmerge system extensions"
   rm -rf /var/lib/extensions/tailscale
   systemd-sysext merge &>/dev/null || echo "ERROR: could not merge system extensions"
@@ -96,12 +96,16 @@ echo "Starting required services..."
 # tailscaled - the tailscale daemon
 # Note: enable and start/restart must be run because the legacy installation stops and disables
 # any existing installations.
-systemctl enable tailscaled
+systemctl enable tailscaled &>/dev/null || echo "ERROR: Could not enable tailscaled service"
 if systemctl is-active --quiet tailscaled; then
-  echo "Upgrade complete. Restarting tailscaled..."
+  echo "Upgrade complete."
+  echo -n "Restarting tailscaled..."
 else
-  echo "Install complete. Starting tailscaled..."
+  echo "Install complete."
+  echo -n "Starting tailscaled..."
 fi
-systemctl restart tailscaled # This needs to be the last thing we do in case the user's running this over Tailscale SSH.
 
-echo "Done."
+# This needs to be the last thing we do in case the user's running this over Tailscale SSH.
+systemctl restart tailscaled &>/dev/null || echo "ERROR: Could not start tailscaled service" 
+
+echo "done."

--- a/tailscale.sh
+++ b/tailscale.sh
@@ -78,12 +78,14 @@ if ! test -f /etc/default/tailscaled; then
   cp -rf $tar_dir/systemd/tailscaled.defaults /etc/default/tailscaled
 fi
 
-# update paths in the unit file
-sed -i 's@/usr/sbin/tailscaled@/opt/tailscale/tailscaled@g' /etc/systemd/system/tailscaled.service
-
 # return to our original directory (silently) and clean up
 popd > /dev/null
 rm -rf "${dir}"
+
+# copy in our overrides file if it doesn't already exist
+if ! test -f /etc/systemd/system/tailscaled.service.d/override.conf; then
+  mkdir -p /etc/systemd/system/tailscaled.service.d
+  cp -rf override.conf /etc/systemd/system/tailscaled.service.d/override.conf
 
 echo "done."
 

--- a/tailscale.sh
+++ b/tailscale.sh
@@ -112,9 +112,12 @@ systemctl restart tailscaled &>/dev/null || echo "ERROR: Could not start tailsca
 echo "done."
 
 if ! command -v tailscale &> /dev/null; then
+  echo 
   echo "Tailscale is installed and running but the binaries are not in your path yet."
   echo "Restart your session or run the following command to add them:"
-  echo "" && echo "source /etc/tailscale" && echo ""
+  echo 
+  echo "source /etc/tailscale"
+  echo
 fi
 
 echo "Installation Complete."

--- a/tailscale.sh
+++ b/tailscale.sh
@@ -91,7 +91,7 @@ rm -rf "${dir}"
 
 echo "done."
 
-echo "Starting required services..."
+echo -n "Starting required services..."
 
 # tailscaled - the tailscale daemon
 # Note: enable and start/restart must be run because the legacy installation stops and disables

--- a/tailscale.sh
+++ b/tailscale.sh
@@ -53,6 +53,8 @@ if test -f /etc/systemd/system/tailscaled.service.d/override.conf; then
   rm -rf /etc/systemd/system/tailscaled.service.d/override.conf
 fi
 
+echo "done."
+
 echo -n "Installing..."
 
 # extract the tailscale binaries
@@ -86,6 +88,8 @@ sed -i 's@/usr/sbin/tailscaled@/opt/tailscale/tailscaled@g' /etc/systemd/system/
 # return to our original directory (silently) and clean up
 popd > /dev/null
 rm -rf "${dir}"
+
+echo "done."
 
 echo "Starting required services..."
 

--- a/tailscale.sh
+++ b/tailscale.sh
@@ -39,11 +39,11 @@ tar_dir="$(echo ${tarball} | cut -d. -f1-3)"
 test -d $tar_dir
 
 # Create binaries directory in home
-mkdir -p /home/deck/.local/bin
+mkdir -p /home/deck/.bin
 
 # pull binaries
-cp -rf $tar_dir/tailscale /home/deck/.local/bin/tailscale
-cp -rf $tar_dir/tailscaled /home/deck/.local/bin/tailscaled
+cp -rf $tar_dir/tailscale /home/deck/.bin/tailscale
+cp -rf $tar_dir/tailscaled /home/deck/.bin/tailscaled
 
 # copy in the defaults file if it doesn't already exist
 if ! test -f /home/deck/.config/tailscaled.defaults; then

--- a/tailscale.sh
+++ b/tailscale.sh
@@ -48,11 +48,6 @@ if [ $(systemd-sysext list 2>/dev/null | grep -c "/var/lib/extensions/tailscale"
   systemd-sysext merge &>/dev/null || echo "ERROR: could not merge system extensions"
 fi
 
-# Remove the overrides conf
-if test -f /etc/systemd/system/tailscaled.service.d/override.conf; then
-  rm -rf /etc/systemd/system/tailscaled.service.d/override.conf
-fi
-
 echo "done."
 
 echo -n "Installing..."

--- a/tailscale.sh
+++ b/tailscale.sh
@@ -116,7 +116,7 @@ if ! command -v tailscale &> /dev/null; then
   echo "Tailscale is installed and running but the binaries are not in your path yet."
   echo "Restart your session or run the following command to add them:"
   echo 
-  echo "source /etc/tailscale"
+  echo "source /etc/profile.d/tailscale.sh"
   echo
 fi
 

--- a/tailscale.sh
+++ b/tailscale.sh
@@ -46,8 +46,8 @@ cp -rf $tar_dir/tailscale /home/deck/.bin/tailscale
 cp -rf $tar_dir/tailscaled /home/deck/.bin/tailscaled
 
 # add binaries to path via bashrc if not already there
-if [ $(cat /home/deck/.bashrc | grep -c "/home/deck/.bin") -eq 0 ]; then
-  echo "/home/deck/.bin" >> /home/deck/.bashrc
+if [ $(cat /home/deck/.bashrc | grep -c 'export PATH="/home/deck/.bin:$PATH"') -eq 0 ]; then
+  echo 'export PATH="/home/deck/.bin:$PATH"' >> /home/deck/.bashrc
 fi
 
 # copy in the defaults file if it doesn't already exist

--- a/tailscale.sh
+++ b/tailscale.sh
@@ -82,11 +82,19 @@ fi
 popd > /dev/null
 rm -rf "${dir}"
 
-# copy in our overrides file if it doesn't already exist
-if ! test -f /etc/systemd/system/tailscaled.service.d/override.conf; then
-  mkdir -p /etc/systemd/system/tailscaled.service.d
-  cp -rf override.conf /etc/systemd/system/tailscaled.service.d/override.conf
+# if an override file already exists, back up and remove
+if test -f /etc/systemd/system/tailscaled.service.d/override.conf; then
+  echo
+  echo "Warning: An existing Tailscaled systemd override file was detected. It must be replaced."
+  echo "A backup of the existing file is being placed at /etc/systemd/system/tailscaled.service.d/override.conf.bak"
+  echo
+  cp -rf /etc/systemd/system/tailscaled.service.d/override.conf /etc/systemd/system/tailscaled.service.d/override.conf.bak
+  rm /etc/systemd/system/tailscaled.service.d/override.conf
 fi
+
+# copy our override file in
+mkdir -p /etc/systemd/system/tailscaled.service.d
+cp -rf override.conf /etc/systemd/system/tailscaled.service.d/override.conf
 
 echo "done."
 

--- a/tailscale.sh
+++ b/tailscale.sh
@@ -97,6 +97,9 @@ fi
 mkdir -p /etc/systemd/system/tailscaled.service.d
 cp -f override.conf /etc/systemd/system/tailscaled.service.d/override.conf
 
+# capture the above override file in systemd
+systemctl daemon-reload
+
 echo "done."
 
 echo -n "Starting required services..."

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,6 @@
+systemctl stop tailscaled
+systemctl disable tailscaled
+rm /etc/systemd/system/tailscaled.service
+rm /etc/default/tailscaled
+rm /etc/profile.d/tailscale.sh
+rm -rf /opt/tailscale/tailscale


### PR DESCRIPTION
Here are the major changes:

- installs binaries to `/home/deck/.bin`
- adds `/home/deck/.bin` to the users path via `.bashrc`
- Installs the tailscale systemd unit in `/etc/systemd/system/tailscaled.service`