### PR TITLE
Add atomic-update configurate to preserve files in /etc

### DIFF
--- a/tailscale.sh
+++ b/tailscale.sh
@@ -73,6 +73,12 @@ if ! test -f /etc/default/tailscaled; then
   cp -rf $tar_dir/systemd/tailscaled.defaults /etc/default/tailscaled
 fi
 
+# add atomic-update.conf.d configuration
+echo <<EOF > /etc/atomic-update.conf.d/tailscale.conf
+/etc/default/tailscaled
+/etc/profile.d/tailscale.sh
+EOF
+
 # return to our original directory (silently) and clean up
 popd > /dev/null
 rm -rf "${dir}"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -3,4 +3,5 @@ systemctl disable tailscaled
 rm /etc/systemd/system/tailscaled.service
 rm /etc/default/tailscaled
 rm /etc/profile.d/tailscale.sh
+rm /etc/atomic-update.conf.d/tailscale.conf
 rm -rf /opt/tailscale/tailscale


### PR DESCRIPTION
SteamOS 3.6 stopped preserving all files in /etc during upgrades. Files to be preserved need to be listed in /etc/atomic-update.conf.d.

Fixes https://github.com/tailscale-dev/deck-tailscale/issues/36
Fixes https://github.com/tailscale-dev/deck-tailscale/issues/20
May help https://github.com/tailscale-dev/deck-tailscale/issues/29