### PR TITLE
Fix creation of atomic-update config file

### DIFF
--- a/tailscale.sh
+++ b/tailscale.sh
@@ -74,7 +74,7 @@ if ! test -f /etc/default/tailscaled; then
 fi
 
 # add atomic-update.conf.d configuration
-echo <<EOF > /etc/atomic-update.conf.d/tailscale.conf
+cat <<EOF > /etc/atomic-update.conf.d/tailscale.conf
 /etc/default/tailscaled
 /etc/profile.d/tailscale.sh
 EOF


### PR DESCRIPTION
Unfortunately I failed to properly test https://github.com/tailscale-dev/deck-tailscale/pull/42 on a clean /etc and made a basic error in the original PR. This would have been caught by running the script through shellcheck too.

The original PR created an empty /etc/atomic-update.conf.d/tailscale.conf, now it will correctly populate it with the names of files to retain after system updates.